### PR TITLE
Automated setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Read more about [Pterodactyl](https://pterodactyl.io/) here. This script is not 
 
 For help and support regarding the script itself and **not the official Pterodactyl project**, you can join the [Discord Chat](https://pterodactyl-installer.se/discord).
 
+### Automated installation
+
+This repository includes `auto_install.sh` for a minimal setup. The script
+prompts only for an admin username and panel hostname, then configures both
+panel and wings using default values.
+
 ## Supported installations
 
 List of supported installation setups for panel and Wings (installations supported by this installation script).

--- a/auto_install.sh
+++ b/auto_install.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+if [[ $EUID -ne 0 ]]; then
+  echo "* This script must be executed as root." >&2
+  exit 1
+fi
+
+read -r -p "Enter admin username: " USERNAME
+read -r -p "Enter panel FQDN: " PANEL_FQDN
+
+ADMIN_EMAIL="${USERNAME}@talkdrove.com"
+PANEL_USER_EMAIL="${USERNAME}@drove.live"
+PANEL_USER_PASSWORD="admin@00"
+DB_PASSWORD=$(openssl rand -base64 16)
+
+export email="$ADMIN_EMAIL"
+export user_email="$PANEL_USER_EMAIL"
+export user_username="$USERNAME"
+export user_firstname="$USERNAME"
+export user_lastname="$USERNAME"
+export user_password="$PANEL_USER_PASSWORD"
+export FQDN="$PANEL_FQDN"
+export timezone="Asia/Karachi"
+export CONFIGURE_LETSENCRYPT=true
+export ASSUME_SSL=false
+export CONFIGURE_FIREWALL=true
+export MYSQL_DB="HTD"
+export MYSQL_USER="SERVER"
+export MYSQL_PASSWORD="$DB_PASSWORD"
+
+bash installers/panel.sh
+
+export CONFIGURE_FIREWALL=true
+bash installers/wings.sh

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ set -e
 
 export GITHUB_SOURCE="v1.1.1"
 export SCRIPT_RELEASE="v1.1.1"
-export GITHUB_BASE_URL="https://raw.githubusercontent.com/pterodactyl-installer/pterodactyl-installer"
+export GITHUB_BASE_URL="https://raw.githubusercontent.com/HyHamza/SERVER-CONFIG"
 
 LOG_PATH="/var/log/pterodactyl-installer.log"
 

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -52,7 +52,7 @@ export SUPPORTED=false
 export PANEL_DL_URL="https://github.com/pterodactyl/panel/releases/latest/download/panel.tar.gz"
 export WINGS_DL_BASE_URL="https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_"
 export MARIADB_URL="https://downloads.mariadb.com/MariaDB/mariadb_repo_setup"
-export GITHUB_BASE_URL=${GITHUB_BASE_URL:-"https://raw.githubusercontent.com/pterodactyl-installer/pterodactyl-installer"}
+export GITHUB_BASE_URL=${GITHUB_BASE_URL:-"https://raw.githubusercontent.com/HyHamza/SERVER-CONFIG"}
 export GITHUB_URL="$GITHUB_BASE_URL/$GITHUB_SOURCE"
 
 # Colors


### PR DESCRIPTION
## Summary
- change GitHub download URLs to HyHamza/SERVER-CONFIG
- add `auto_install.sh` for automatic installation
- document how to use the automated script

## Testing
- `apt-get update`
- `apt-get install -y shellcheck`
- `shellcheck auto_install.sh`

------
https://chatgpt.com/codex/tasks/task_b_6876cee5689c8329a80b656898880fa5