### PR TITLE
Allow alt SSH port

### DIFF
--- a/installers/panel.sh
+++ b/installers/panel.sh
@@ -330,9 +330,9 @@ dep_install() {
 # --------------- Other functions -------------- #
 
 firewall_ports() {
-  output "Opening ports: 22 (SSH), 80 (HTTP) and 443 (HTTPS)"
+  output "Opening ports: 22 (SSH), 22022 (Alt SSH), 80 (HTTP) and 443 (HTTPS)"
 
-  firewall_allow_ports "22 80 443"
+  firewall_allow_ports "22 22022 80 443"
 
   success "Firewall ports opened!"
 }

--- a/installers/wings.sh
+++ b/installers/wings.sh
@@ -133,13 +133,15 @@ systemd_file() {
 }
 
 firewall_ports() {
-  output "Opening port 22 (SSH), 8080 (Wings Port), 2022 (Wings SFTP Port)"
+  output "Opening port 22 (SSH), 22022 (Alt SSH), 8080 (Wings Port), 2022 (Wings SFTP Port)"
 
   [ "$CONFIGURE_LETSENCRYPT" == true ] && firewall_allow_ports "80 443"
   [ "$CONFIGURE_DB_FIREWALL" == true ] && firewall_allow_ports "3306"
 
   firewall_allow_ports "22"
   output "Allowed port 22"
+  firewall_allow_ports "22022"
+  output "Allowed port 22022"
   firewall_allow_ports "8080"
   output "Allowed port 8080"
   firewall_allow_ports "2022"


### PR DESCRIPTION
## Summary
- open port 22022 when configuring the firewall

## Testing
- `shellcheck installers/panel.sh installers/wings.sh`

------
https://chatgpt.com/codex/tasks/task_b_68795bc7fba08329a9cbc6f6d5f163fb