### PR TITLE
Add admin credentials output

### DIFF
--- a/auto_install.sh
+++ b/auto_install.sh
@@ -155,7 +155,9 @@ else
   fi
 
   echo "* Installation completed successfully"
+  echo "* Admin Username: $USERNAME"
   echo "* Admin Email: $ADMIN_EMAIL"
+  echo "* Admin Password: $PANEL_USER_PASSWORD"
   [[ "$INSTALL_PANEL" == true ]] && echo "* Panel FQDN: $PANEL_FQDN"
   [[ "$INSTALL_WINGS" == true ]] && echo "* Wings FQDN: $WINGS_FQDN"
   [[ "$INSTALL_PANEL" == true ]] && echo "* Database Password: $DB_PASSWORD"


### PR DESCRIPTION
## Summary
- print admin username and password after installation

## Testing
- `shellcheck auto_install.sh`


------
https://chatgpt.com/codex/tasks/task_b_68796405c1b48329ba3506c28073e189