### PR TITLE
Fix path handling for lib.sh and add Oracle Linux support

### DIFF
--- a/auto_install.sh
+++ b/auto_install.sh
@@ -119,10 +119,11 @@ echo "* Downloading uninstall.sh..."
 curl -sSL -o "$TMP_DIR/uninstall.sh" "$GITHUB_BASE_URL/$GITHUB_SOURCE/installers/uninstall.sh"
 
 echo "* Downloading lib.sh..."
-curl -sSL -o "$TMP_DIR/lib.sh" "$GITHUB_BASE_URL/$GITHUB_SOURCE/lib/lib.sh"
+[ -f /tmp/lib.sh ] && rm -rf /tmp/lib.sh
+curl -sSL -o "/tmp/lib.sh" "$GITHUB_BASE_URL/$GITHUB_SOURCE/lib/lib.sh"
 
 # Verify downloads
-if [[ ! -f "$TMP_DIR/panel.sh" ]] || [[ ! -f "$TMP_DIR/wings.sh" ]] || [[ ! -f "$TMP_DIR/uninstall.sh" ]] || [[ ! -f "$TMP_DIR/lib.sh" ]]; then
+if [[ ! -f "$TMP_DIR/panel.sh" ]] || [[ ! -f "$TMP_DIR/wings.sh" ]] || [[ ! -f "$TMP_DIR/uninstall.sh" ]] || [[ ! -f "/tmp/lib.sh" ]]; then
     echo "* Error: Failed to download required files from GitHub" >&2
     rm -rf "$TMP_DIR"
     exit 1

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -539,7 +539,7 @@ debian)
   [ "$OS_VER_MAJOR" == "12" ] && SUPPORTED=true
   export DEBIAN_FRONTEND=noninteractive
   ;;
-rocky | almalinux)
+rocky | almalinux | ol | oracle | oraclelinux)
   [ "$OS_VER_MAJOR" == "8" ] && SUPPORTED=true
   [ "$OS_VER_MAJOR" == "9" ] && SUPPORTED=true
   ;;


### PR DESCRIPTION
## Summary
- download `lib.sh` to `/tmp/lib.sh` so installers can find it
- recognize Oracle Linux in OS detection

## Testing
- `shellcheck auto_install.sh`
- `shellcheck lib/lib.sh`

------
https://chatgpt.com/codex/tasks/task_b_687c195608608329bd460c65b98ca073